### PR TITLE
Add overwrite-default settings, unsaved title indicator, and theme system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ tbm-utils
 pyBIG
 watchdog
 pyqtdarktheme
-qt-material
 ruff
 PyOpenGL
 PyOpenGL_accelerate

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,12 +11,12 @@ tbm-utils
 pyBIG
 watchdog
 pyqtdarktheme
+qt-material
 ruff
 PyOpenGL
 PyOpenGL_accelerate
 webbrowser
 moddb
 requests
-git+https://github.com/el1s7/curl-adapter.git -U --ignore-installed
 platformdirs
 numpy

--- a/src/assets/theme/branch_end.svg
+++ b/src/assets/theme/branch_end.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><line x1="8" y1="0" x2="8" y2="8" stroke="currentColor" stroke-width="1"/><line x1="8" y1="8" x2="16" y2="8" stroke="currentColor" stroke-width="1"/></svg>

--- a/src/assets/theme/branch_more.svg
+++ b/src/assets/theme/branch_more.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><line x1="8" y1="0" x2="8" y2="16" stroke="currentColor" stroke-width="1"/><line x1="8" y1="8" x2="16" y2="8" stroke="currentColor" stroke-width="1"/></svg>

--- a/src/assets/theme/chevron_down.svg
+++ b/src/assets/theme/chevron_down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/assets/theme/chevron_right.svg
+++ b/src/assets/theme/chevron_right.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M6 4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/assets/theme/combobox_arrow.svg
+++ b/src/assets/theme/combobox_arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M4 6l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/src/assets/theme/vline.svg
+++ b/src/assets/theme/vline.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><line x1="8" y1="0" x2="8" y2="16" stroke="currentColor" stroke-width="1"/></svg>

--- a/src/main.py
+++ b/src/main.py
@@ -509,12 +509,9 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         self.setWindowTitle(title)
 
     def has_unsaved_changes(self) -> bool:
-        if self.archive is not None and getattr(self.archive, "modified_entries", None):
+        if self.archive is not None and self.archive.modified_entries:
             return True
-        for i in range(self.tabs.count()):
-            if getattr(self.tabs.widget(i), "unsaved", False):
-                return True
-        return False
+        return any(self.tabs.widget(i).unsaved for i in range(self.tabs.count()))
 
     def _save(self, path):
         if path is None:

--- a/src/main.py
+++ b/src/main.py
@@ -743,7 +743,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                         QMessageBox.StandardButton.Yes
                         | QMessageBox.StandardButton.No
                         | QMessageBox.StandardButton.YesToAll,
-                        QMessageBox.StandardButton.YesToAll,
+                        QMessageBox.StandardButton.No,
                     )
                     if ret == QMessageBox.StandardButton.No:
                         continue
@@ -926,7 +926,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                         QMessageBox.StandardButton.Yes
                         | QMessageBox.StandardButton.No
                         | QMessageBox.StandardButton.YesToAll,
-                        QMessageBox.StandardButton.YesToAll,
+                        QMessageBox.StandardButton.No,
                     )
                     if ret == QMessageBox.StandardButton.No:
                         return ret

--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,7 @@ from PyQt6.QtWidgets import (
 from file_views import get_file_view_class
 from misc import NewTabDialog, WrappingInputDialog
 from search import SearchManager
-from settings import FileTab, FileView, Settings, Workplace
+from settings import FileTab, FileView, OverwriteDefault, Settings, Workplace
 from tabs import get_tab_from_file_type
 from ui import HasUiElements, generate_ui
 from undo import AddFileCommand, DeleteFilesCommand, RenameFileCommand, UndoStack
@@ -730,12 +730,12 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             )
             QApplication.processEvents()
             if self.archive.file_exists(file):
-                default = "yes" if skip_all else self.settings.extract_overwrite_default
-                if default == "no":
+                default = (
+                    OverwriteDefault.OVERWRITE if skip_all else self.settings.extract_overwrite_default
+                )
+                if default is OverwriteDefault.SKIP:
                     continue
-                if default == "yes_to_all":
-                    skip_all = True
-                elif default == "ask":
+                if default is OverwriteDefault.ASK:
                     ret = QMessageBox.question(
                         self,
                         "Overwrite file?",
@@ -914,12 +914,10 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             replaced_data = self.archive.read_file(name)
             if not skip_all:
                 default = self.settings.add_overwrite_default
-                if default == "yes_to_all":
-                    ret = QMessageBox.StandardButton.YesToAll
-                elif default == "yes":
-                    ret = QMessageBox.StandardButton.Yes
-                elif default == "no":
+                if default is OverwriteDefault.SKIP:
                     return QMessageBox.StandardButton.No
+                if default is OverwriteDefault.OVERWRITE:
+                    ret = QMessageBox.StandardButton.YesToAll
                 else:
                     ret = QMessageBox.question(
                         self,

--- a/src/main.py
+++ b/src/main.py
@@ -730,29 +730,25 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             )
             QApplication.processEvents()
             if self.archive.file_exists(file):
-                if not skip_all:
-                    default = self.settings.extract_overwrite_default
-                    if default == "yes_to_all":
-                        skip_all = True
-                    elif default == "yes":
-                        pass
-                    elif default == "no":
+                default = "yes" if skip_all else self.settings.extract_overwrite_default
+                if default == "no":
+                    continue
+                if default == "yes_to_all":
+                    skip_all = True
+                elif default == "ask":
+                    ret = QMessageBox.question(
+                        self,
+                        "Overwrite file?",
+                        f"<b>{file}</b> already exists, overwrite?",
+                        QMessageBox.StandardButton.Yes
+                        | QMessageBox.StandardButton.No
+                        | QMessageBox.StandardButton.YesToAll,
+                        QMessageBox.StandardButton.YesToAll,
+                    )
+                    if ret == QMessageBox.StandardButton.No:
                         continue
-                    else:
-                        ret = QMessageBox.question(
-                            self,
-                            "Overwrite file?",
-                            f"<b>{file}</b> already exists, overwrite?",
-                            QMessageBox.StandardButton.Yes
-                            | QMessageBox.StandardButton.No
-                            | QMessageBox.StandardButton.YesToAll,
-                            QMessageBox.StandardButton.YesToAll,
-                        )
-                        if ret == QMessageBox.StandardButton.No:
-                            continue
-
-                        if ret == QMessageBox.StandardButton.YesToAll:
-                            skip_all = True
+                    if ret == QMessageBox.StandardButton.YesToAll:
+                        skip_all = True
 
                 self.archive.remove_file(file)
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 import moddb
-import qdarktheme
 from pyBIG import InDiskArchive, InMemoryArchive, base_archive
 from PyQt6.QtCore import QEvent, Qt, QTimer
 from PyQt6.QtGui import (
@@ -130,10 +129,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
         self.settings = Settings(self)
         self.undo_stack = UndoStack(self.settings.undo_stack_size)
-        if self.settings.dark_mode:
-            qdarktheme.setup_theme("dark", corner_shape="sharp")
-        else:
-            qdarktheme.setup_theme("light", corner_shape="sharp")
+        self.settings.apply_theme()
 
         generate_ui(self)
 
@@ -505,11 +501,20 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         if name is None:
             name = self.path or "Untitled Archive"
 
-        title = f"{os.path.basename(name)} - {self.base_name}"
+        prefix = "*" if self.has_unsaved_changes() else ""
+        title = f"{prefix}{os.path.basename(name)} - {self.base_name}"
         if self.workspace_name:
-            title = f"{os.path.basename(name)} [{self.workspace_name}] - {self.base_name}"
+            title = f"{prefix}{os.path.basename(name)} [{self.workspace_name}] - {self.base_name}"
 
         self.setWindowTitle(title)
+
+    def has_unsaved_changes(self) -> bool:
+        if self.archive is not None and getattr(self.archive, "modified_entries", None):
+            return True
+        for i in range(self.tabs.count()):
+            if getattr(self.tabs.widget(i), "unsaved", False):
+                return True
+        return False
 
     def _save(self, path):
         if path is None:
@@ -698,6 +703,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
         self.settings.last_dir = os.path.dirname(files[0])
         self.listwidget.add_files(files_added)
+        self.update_archive_name()
 
     def _merge_archives(self, path):
         if self.settings.large_archive:
@@ -728,20 +734,28 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             QApplication.processEvents()
             if self.archive.file_exists(file):
                 if not skip_all:
-                    ret = QMessageBox.question(
-                        self,
-                        "Overwrite file?",
-                        f"<b>{file}</b> already exists, overwrite?",
-                        QMessageBox.StandardButton.Yes
-                        | QMessageBox.StandardButton.No
-                        | QMessageBox.StandardButton.YesToAll,
-                        QMessageBox.StandardButton.No,
-                    )
-                    if ret == QMessageBox.StandardButton.No:
-                        continue
-
-                    if ret == QMessageBox.StandardButton.YesToAll:
+                    default = self.settings.extract_overwrite_default
+                    if default == "yes_to_all":
                         skip_all = True
+                    elif default == "yes":
+                        pass
+                    elif default == "no":
+                        continue
+                    else:
+                        ret = QMessageBox.question(
+                            self,
+                            "Overwrite file?",
+                            f"<b>{file}</b> already exists, overwrite?",
+                            QMessageBox.StandardButton.Yes
+                            | QMessageBox.StandardButton.No
+                            | QMessageBox.StandardButton.YesToAll,
+                            QMessageBox.StandardButton.YesToAll,
+                        )
+                        if ret == QMessageBox.StandardButton.No:
+                            continue
+
+                        if ret == QMessageBox.StandardButton.YesToAll:
+                            skip_all = True
 
                 self.archive.remove_file(file)
 
@@ -898,6 +912,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                     skip_all = True
 
         self.listwidget.add_files(files_to_add)
+        self.update_archive_name()
 
     def add_file_to_archive(self, url, name, blank=False, skip_all=False, undoable=True):
         replaced_data = None
@@ -905,17 +920,25 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         if self.archive.file_exists(name):
             replaced_data = self.archive.read_file(name)
             if not skip_all:
-                ret = QMessageBox.question(
-                    self,
-                    "Overwrite file?",
-                    f"<b>{name}</b> already exists, overwrite?",
-                    QMessageBox.StandardButton.Yes
-                    | QMessageBox.StandardButton.No
-                    | QMessageBox.StandardButton.YesToAll,
-                    QMessageBox.StandardButton.No,
-                )
-                if ret == QMessageBox.StandardButton.No:
-                    return ret
+                default = self.settings.add_overwrite_default
+                if default == "yes_to_all":
+                    ret = QMessageBox.StandardButton.YesToAll
+                elif default == "yes":
+                    ret = QMessageBox.StandardButton.Yes
+                elif default == "no":
+                    return QMessageBox.StandardButton.No
+                else:
+                    ret = QMessageBox.question(
+                        self,
+                        "Overwrite file?",
+                        f"<b>{name}</b> already exists, overwrite?",
+                        QMessageBox.StandardButton.Yes
+                        | QMessageBox.StandardButton.No
+                        | QMessageBox.StandardButton.YesToAll,
+                        QMessageBox.StandardButton.YesToAll,
+                    )
+                    if ret == QMessageBox.StandardButton.No:
+                        return ret
 
             self.archive.remove_file(name)
 
@@ -1192,6 +1215,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
     def update_undo_redo_actions(self):
         self.undo_action.setEnabled(self.undo_stack.can_undo)
         self.redo_action.setEnabled(self.undo_stack.can_redo)
+        self.update_archive_name()
 
     def refresh_tabs(self, files: list[str]):
         for i in range(self.tabs.count()):

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -150,6 +150,10 @@ def build_palette(scheme: dict) -> QPalette:
 def build_stylesheet(scheme: dict) -> str:
     s = scheme
     return f"""
+    QMainWindow, QDialog {{
+        background-color: {s['window']};
+        color: {s['window_text']};
+    }}
     QToolTip {{
         color: {s['tooltip_text']};
         background-color: {s['tooltip_base']};
@@ -190,20 +194,81 @@ def build_stylesheet(scheme: dict) -> str:
     QTabBar::tab:hover {{
         background: {s['menu_hover']};
     }}
-    QScrollBar:vertical, QScrollBar:horizontal {{
-        background: {s['base']};
-        border: none;
+    QTabBar::tab:disabled {{
+        color: {s['disabled_text']};
     }}
-    QScrollBar::handle {{
+    QTreeView, QTreeWidget, QListView, QListWidget {{
+        background-color: {s['base']};
+        alternate-background-color: {s['alt_base']};
+        color: {s['text']};
+        border: 1px solid {s['border']};
+        outline: 0;
+    }}
+    QTreeView::item, QTreeWidget::item, QListView::item, QListWidget::item {{
+        color: {s['text']};
+        padding: 2px;
+    }}
+    QTreeView::item:hover, QTreeWidget::item:hover, QListView::item:hover, QListWidget::item:hover {{
+        background-color: {s['menu_hover']};
+    }}
+    QTreeView::item:selected, QTreeWidget::item:selected, QListView::item:selected, QListWidget::item:selected {{
+        background-color: {s['highlight']};
+        color: {s['highlight_text']};
+    }}
+    QTreeView::item:selected:!active, QTreeWidget::item:selected:!active,
+    QListView::item:selected:!active, QListWidget::item:selected:!active {{
+        background-color: {s['highlight']};
+        color: {s['highlight_text']};
+    }}
+    QTreeView::branch {{
+        background-color: {s['base']};
+    }}
+    QTreeView::branch:hover {{
+        background-color: {s['menu_hover']};
+    }}
+    QTreeView::branch:selected {{
+        background-color: {s['highlight']};
+    }}
+    QScrollBar:vertical {{
+        background: {s['base']};
+        width: 12px;
+        border: none;
+        margin: 0;
+    }}
+    QScrollBar:horizontal {{
+        background: {s['base']};
+        height: 12px;
+        border: none;
+        margin: 0;
+    }}
+    QScrollBar::handle:vertical {{
         background: {s['scrollbar']};
         border-radius: 3px;
+        min-height: 20px;
+    }}
+    QScrollBar::handle:horizontal {{
+        background: {s['scrollbar']};
+        border-radius: 3px;
+        min-width: 20px;
     }}
     QScrollBar::handle:hover {{
         background: {s['highlight']};
     }}
+    QScrollBar::add-page, QScrollBar::sub-page {{
+        background: {s['base']};
+    }}
     QScrollBar::add-line, QScrollBar::sub-line {{
         background: none;
         border: none;
+        width: 0;
+        height: 0;
+    }}
+    QScrollBar::up-arrow, QScrollBar::down-arrow,
+    QScrollBar::left-arrow, QScrollBar::right-arrow {{
+        background: none;
+        border: none;
+        width: 0;
+        height: 0;
     }}
     QHeaderView::section {{
         background-color: {s['base']};
@@ -218,24 +283,61 @@ def build_stylesheet(scheme: dict) -> str:
         selection-background-color: {s['highlight']};
         selection-color: {s['highlight_text']};
     }}
-    QPushButton {{
+    QComboBox::drop-down {{
+        border: none;
+        background: {s['base']};
+        width: 16px;
+    }}
+    QComboBox QAbstractItemView {{
+        background-color: {s['base']};
+        color: {s['text']};
+        border: 1px solid {s['border']};
+        selection-background-color: {s['highlight']};
+        selection-color: {s['highlight_text']};
+        outline: 0;
+    }}
+    QCheckBox {{
+        color: {s['text']};
+        spacing: 6px;
+    }}
+    QCheckBox::indicator {{
+        width: 14px;
+        height: 14px;
+        border: 1px solid {s['border']};
+        background-color: {s['base']};
+    }}
+    QCheckBox::indicator:hover {{
+        border: 1px solid {s['highlight']};
+    }}
+    QCheckBox::indicator:checked {{
+        background-color: {s['highlight']};
+        border: 1px solid {s['highlight']};
+    }}
+    QCheckBox::indicator:disabled {{
+        background-color: {s['alt_base']};
+        border: 1px solid {s['disabled_text']};
+    }}
+    QPushButton, QToolButton {{
         background-color: {s['button']};
         color: {s['button_text']};
         border: 1px solid {s['border']};
         padding: 4px 10px;
     }}
-    QPushButton:hover {{
+    QPushButton:hover, QToolButton:hover {{
         background-color: {s['menu_hover']};
     }}
-    QPushButton:pressed {{
+    QPushButton:pressed, QToolButton:pressed {{
         background-color: {s['highlight']};
         color: {s['highlight_text']};
     }}
-    QPushButton:disabled {{
+    QPushButton:disabled, QToolButton:disabled {{
         color: {s['disabled_text']};
     }}
     QSplitter::handle {{
         background-color: {s['border']};
+    }}
+    QSplitter::handle:hover {{
+        background-color: {s['highlight']};
     }}
     QStatusBar {{
         background-color: {s['window']};

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -1,5 +1,6 @@
+import hashlib
 import os
-from urllib.parse import quote
+import tempfile
 
 from PyQt6.QtGui import QColor, QPalette
 
@@ -28,11 +29,19 @@ def _load_glyphs() -> dict:
 
 
 _GLYPHS = _load_glyphs()
+_CACHE_DIR = os.path.join(tempfile.gettempdir(), "finalbigv2_theme")
 
 
-def _data_uri(svg_text: str, color: str) -> str:
-    tinted = svg_text.replace("currentColor", color)
-    return "data:image/svg+xml;utf8," + quote(tinted, safe="")
+def _tinted_path(name: str, color: str) -> str:
+    """Write a tinted SVG to a temp cache and return a forward-slash file URL."""
+    os.makedirs(_CACHE_DIR, exist_ok=True)
+    digest = hashlib.md5(color.encode("ascii")).hexdigest()[:8]
+    out = os.path.join(_CACHE_DIR, f"{name}_{digest}.svg")
+    if not os.path.exists(out):
+        tinted = _GLYPHS[name].replace("currentColor", color)
+        with open(out, "w", encoding="utf-8") as f:
+            f.write(tinted)
+    return out.replace("\\", "/")
 
 NORD = {
     "is_dark": True,
@@ -185,12 +194,12 @@ def build_stylesheet(scheme: dict) -> str:
     s = scheme
     fg = s["text"]
     line = s["border"]
-    chevron_right = _data_uri(_GLYPHS["chevron_right"], fg)
-    chevron_down = _data_uri(_GLYPHS["chevron_down"], fg)
-    vline = _data_uri(_GLYPHS["vline"], line)
-    branch_more = _data_uri(_GLYPHS["branch_more"], line)
-    branch_end = _data_uri(_GLYPHS["branch_end"], line)
-    combobox_arrow = _data_uri(_GLYPHS["combobox_arrow"], fg)
+    chevron_right = _tinted_path("chevron_right", fg)
+    chevron_down = _tinted_path("chevron_down", fg)
+    vline = _tinted_path("vline", line)
+    branch_more = _tinted_path("branch_more", line)
+    branch_end = _tinted_path("branch_end", line)
+    combobox_arrow = _tinted_path("combobox_arrow", fg)
     return f"""
     QMainWindow, QDialog {{
         background-color: {s['window']};
@@ -272,16 +281,13 @@ def build_stylesheet(scheme: dict) -> str:
         background-color: {s['highlight']};
     }}
     QTreeView::branch:has-siblings:!adjoins-item {{
-        border-image: none;
-        image: url({vline});
+        border-image: url({vline}) 0;
     }}
     QTreeView::branch:has-siblings:adjoins-item {{
-        border-image: none;
-        image: url({branch_more});
+        border-image: url({branch_more}) 0;
     }}
     QTreeView::branch:!has-children:!has-siblings:adjoins-item {{
-        border-image: none;
-        image: url({branch_end});
+        border-image: url({branch_end}) 0;
     }}
     QTreeView::branch:has-children:!has-siblings:closed,
     QTreeView::branch:has-children:has-siblings:closed {{

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -1,4 +1,38 @@
+import os
+from urllib.parse import quote
+
 from PyQt6.QtGui import QColor, QPalette
+
+from utils.utils import resource_path
+
+_GLYPH_NAMES = (
+    "chevron_right",
+    "chevron_down",
+    "vline",
+    "branch_more",
+    "branch_end",
+    "combobox_arrow",
+)
+
+
+def _load_glyphs() -> dict:
+    glyphs = {}
+    for name in _GLYPH_NAMES:
+        path = resource_path(os.path.join("theme", f"{name}.svg"))
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                glyphs[name] = f.read()
+        except OSError:
+            glyphs[name] = ""
+    return glyphs
+
+
+_GLYPHS = _load_glyphs()
+
+
+def _data_uri(svg_text: str, color: str) -> str:
+    tinted = svg_text.replace("currentColor", color)
+    return "data:image/svg+xml;utf8," + quote(tinted, safe="")
 
 NORD = {
     "is_dark": True,
@@ -149,6 +183,14 @@ def build_palette(scheme: dict) -> QPalette:
 
 def build_stylesheet(scheme: dict) -> str:
     s = scheme
+    fg = s["text"]
+    line = s["border"]
+    chevron_right = _data_uri(_GLYPHS["chevron_right"], fg)
+    chevron_down = _data_uri(_GLYPHS["chevron_down"], fg)
+    vline = _data_uri(_GLYPHS["vline"], line)
+    branch_more = _data_uri(_GLYPHS["branch_more"], line)
+    branch_end = _data_uri(_GLYPHS["branch_end"], line)
+    combobox_arrow = _data_uri(_GLYPHS["combobox_arrow"], fg)
     return f"""
     QMainWindow, QDialog {{
         background-color: {s['window']};
@@ -229,6 +271,28 @@ def build_stylesheet(scheme: dict) -> str:
     QTreeView::branch:selected {{
         background-color: {s['highlight']};
     }}
+    QTreeView::branch:has-siblings:!adjoins-item {{
+        border-image: none;
+        image: url({vline});
+    }}
+    QTreeView::branch:has-siblings:adjoins-item {{
+        border-image: none;
+        image: url({branch_more});
+    }}
+    QTreeView::branch:!has-children:!has-siblings:adjoins-item {{
+        border-image: none;
+        image: url({branch_end});
+    }}
+    QTreeView::branch:has-children:!has-siblings:closed,
+    QTreeView::branch:has-children:has-siblings:closed {{
+        border-image: none;
+        image: url({chevron_right});
+    }}
+    QTreeView::branch:open:has-children:!has-siblings,
+    QTreeView::branch:open:has-children:has-siblings {{
+        border-image: none;
+        image: url({chevron_down});
+    }}
     QScrollBar:vertical {{
         background: {s['base']};
         width: 12px;
@@ -283,10 +347,21 @@ def build_stylesheet(scheme: dict) -> str:
         selection-background-color: {s['highlight']};
         selection-color: {s['highlight_text']};
     }}
+    QComboBox:focus, QComboBox:on {{
+        border: 1px solid {s['highlight']};
+    }}
     QComboBox::drop-down {{
         border: none;
         background: {s['base']};
         width: 16px;
+    }}
+    QComboBox::down-arrow {{
+        image: url({combobox_arrow});
+        width: 10px;
+        height: 10px;
+    }}
+    QComboBox::down-arrow:on {{
+        image: url({chevron_down});
     }}
     QComboBox QAbstractItemView {{
         background-color: {s['base']};
@@ -295,6 +370,7 @@ def build_stylesheet(scheme: dict) -> str:
         selection-background-color: {s['highlight']};
         selection-color: {s['highlight_text']};
         outline: 0;
+        padding: 2px;
     }}
     QCheckBox {{
         color: {s['text']};

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -1,0 +1,254 @@
+from PyQt6.QtGui import QColor, QPalette
+
+NORD = {
+    "is_dark": True,
+    "window": "#2E3440",
+    "window_text": "#D8DEE9",
+    "base": "#3B4252",
+    "alt_base": "#434C5E",
+    "text": "#ECEFF4",
+    "button": "#3B4252",
+    "button_text": "#ECEFF4",
+    "bright_text": "#BF616A",
+    "highlight": "#5E81AC",
+    "highlight_text": "#ECEFF4",
+    "link": "#88C0D0",
+    "disabled_text": "#4C566A",
+    "tooltip_base": "#434C5E",
+    "tooltip_text": "#ECEFF4",
+    "border": "#4C566A",
+    "menu_hover": "#434C5E",
+    "scrollbar": "#4C566A",
+}
+
+SOLARIZED_DARK = {
+    "is_dark": True,
+    "window": "#002B36",
+    "window_text": "#93A1A1",
+    "base": "#073642",
+    "alt_base": "#002B36",
+    "text": "#EEE8D5",
+    "button": "#073642",
+    "button_text": "#93A1A1",
+    "bright_text": "#DC322F",
+    "highlight": "#268BD2",
+    "highlight_text": "#FDF6E3",
+    "link": "#2AA198",
+    "disabled_text": "#586E75",
+    "tooltip_base": "#073642",
+    "tooltip_text": "#EEE8D5",
+    "border": "#586E75",
+    "menu_hover": "#073642",
+    "scrollbar": "#586E75",
+}
+
+SOLARIZED_LIGHT = {
+    "is_dark": False,
+    "window": "#FDF6E3",
+    "window_text": "#586E75",
+    "base": "#EEE8D5",
+    "alt_base": "#FDF6E3",
+    "text": "#073642",
+    "button": "#EEE8D5",
+    "button_text": "#586E75",
+    "bright_text": "#DC322F",
+    "highlight": "#268BD2",
+    "highlight_text": "#FDF6E3",
+    "link": "#2AA198",
+    "disabled_text": "#93A1A1",
+    "tooltip_base": "#EEE8D5",
+    "tooltip_text": "#073642",
+    "border": "#93A1A1",
+    "menu_hover": "#EEE8D5",
+    "scrollbar": "#93A1A1",
+}
+
+DRACULA = {
+    "is_dark": True,
+    "window": "#282A36",
+    "window_text": "#F8F8F2",
+    "base": "#21222C",
+    "alt_base": "#282A36",
+    "text": "#F8F8F2",
+    "button": "#44475A",
+    "button_text": "#F8F8F2",
+    "bright_text": "#FF5555",
+    "highlight": "#BD93F9",
+    "highlight_text": "#282A36",
+    "link": "#8BE9FD",
+    "disabled_text": "#6272A4",
+    "tooltip_base": "#44475A",
+    "tooltip_text": "#F8F8F2",
+    "border": "#44475A",
+    "menu_hover": "#44475A",
+    "scrollbar": "#44475A",
+}
+
+GRUVBOX_DARK = {
+    "is_dark": True,
+    "window": "#282828",
+    "window_text": "#EBDBB2",
+    "base": "#3C3836",
+    "alt_base": "#32302F",
+    "text": "#EBDBB2",
+    "button": "#3C3836",
+    "button_text": "#EBDBB2",
+    "bright_text": "#FB4934",
+    "highlight": "#458588",
+    "highlight_text": "#FBF1C7",
+    "link": "#83A598",
+    "disabled_text": "#7C6F64",
+    "tooltip_base": "#3C3836",
+    "tooltip_text": "#EBDBB2",
+    "border": "#504945",
+    "menu_hover": "#504945",
+    "scrollbar": "#504945",
+}
+
+PALETTE_THEMES = {
+    "nord": ("Nord", NORD),
+    "solarized_dark": ("Solarized Dark", SOLARIZED_DARK),
+    "solarized_light": ("Solarized Light", SOLARIZED_LIGHT),
+    "dracula": ("Dracula", DRACULA),
+    "gruvbox_dark": ("Gruvbox Dark", GRUVBOX_DARK),
+}
+
+
+def _c(hex_str: str) -> QColor:
+    return QColor(hex_str)
+
+
+def build_palette(scheme: dict) -> QPalette:
+    p = QPalette()
+    role = QPalette.ColorRole
+    group = QPalette.ColorGroup
+
+    p.setColor(role.Window, _c(scheme["window"]))
+    p.setColor(role.WindowText, _c(scheme["window_text"]))
+    p.setColor(role.Base, _c(scheme["base"]))
+    p.setColor(role.AlternateBase, _c(scheme["alt_base"]))
+    p.setColor(role.Text, _c(scheme["text"]))
+    p.setColor(role.Button, _c(scheme["button"]))
+    p.setColor(role.ButtonText, _c(scheme["button_text"]))
+    p.setColor(role.BrightText, _c(scheme["bright_text"]))
+    p.setColor(role.Highlight, _c(scheme["highlight"]))
+    p.setColor(role.HighlightedText, _c(scheme["highlight_text"]))
+    p.setColor(role.Link, _c(scheme["link"]))
+    p.setColor(role.ToolTipBase, _c(scheme["tooltip_base"]))
+    p.setColor(role.ToolTipText, _c(scheme["tooltip_text"]))
+    p.setColor(role.PlaceholderText, _c(scheme["disabled_text"]))
+
+    disabled = _c(scheme["disabled_text"])
+    p.setColor(group.Disabled, role.Text, disabled)
+    p.setColor(group.Disabled, role.WindowText, disabled)
+    p.setColor(group.Disabled, role.ButtonText, disabled)
+    p.setColor(group.Disabled, role.HighlightedText, disabled)
+
+    return p
+
+
+def build_stylesheet(scheme: dict) -> str:
+    s = scheme
+    return f"""
+    QToolTip {{
+        color: {s['tooltip_text']};
+        background-color: {s['tooltip_base']};
+        border: 1px solid {s['border']};
+    }}
+    QMenu {{
+        background-color: {s['base']};
+        color: {s['text']};
+        border: 1px solid {s['border']};
+    }}
+    QMenu::item:selected {{
+        background-color: {s['menu_hover']};
+    }}
+    QMenu::separator {{
+        height: 1px;
+        background: {s['border']};
+        margin: 4px 0;
+    }}
+    QMenuBar {{
+        background-color: {s['window']};
+        color: {s['window_text']};
+    }}
+    QMenuBar::item:selected {{
+        background-color: {s['menu_hover']};
+    }}
+    QTabWidget::pane {{
+        border: 1px solid {s['border']};
+    }}
+    QTabBar::tab {{
+        background: {s['base']};
+        color: {s['text']};
+        padding: 5px 10px;
+        border: 1px solid {s['border']};
+    }}
+    QTabBar::tab:selected {{
+        background: {s['alt_base']};
+    }}
+    QTabBar::tab:hover {{
+        background: {s['menu_hover']};
+    }}
+    QScrollBar:vertical, QScrollBar:horizontal {{
+        background: {s['base']};
+        border: none;
+    }}
+    QScrollBar::handle {{
+        background: {s['scrollbar']};
+        border-radius: 3px;
+    }}
+    QScrollBar::handle:hover {{
+        background: {s['highlight']};
+    }}
+    QScrollBar::add-line, QScrollBar::sub-line {{
+        background: none;
+        border: none;
+    }}
+    QHeaderView::section {{
+        background-color: {s['base']};
+        color: {s['text']};
+        padding: 4px;
+        border: 1px solid {s['border']};
+    }}
+    QLineEdit, QPlainTextEdit, QTextEdit, QComboBox, QSpinBox {{
+        background-color: {s['base']};
+        color: {s['text']};
+        border: 1px solid {s['border']};
+        selection-background-color: {s['highlight']};
+        selection-color: {s['highlight_text']};
+    }}
+    QPushButton {{
+        background-color: {s['button']};
+        color: {s['button_text']};
+        border: 1px solid {s['border']};
+        padding: 4px 10px;
+    }}
+    QPushButton:hover {{
+        background-color: {s['menu_hover']};
+    }}
+    QPushButton:pressed {{
+        background-color: {s['highlight']};
+        color: {s['highlight_text']};
+    }}
+    QPushButton:disabled {{
+        color: {s['disabled_text']};
+    }}
+    QSplitter::handle {{
+        background-color: {s['border']};
+    }}
+    QStatusBar {{
+        background-color: {s['window']};
+        color: {s['window_text']};
+    }}
+    QGroupBox {{
+        border: 1px solid {s['border']};
+        margin-top: 8px;
+    }}
+    QGroupBox::title {{
+        color: {s['text']};
+        subcontrol-origin: margin;
+        left: 8px;
+        padding: 0 4px;
+    }}
+    """

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -238,6 +238,9 @@ def build_stylesheet(scheme: dict) -> str:
         color: {s['text']};
         border: 1px solid {s['border']};
     }}
+    QMenu::item {{
+        padding: 4px 24px 4px 24px;
+    }}
     QMenu::item:selected {{
         background-color: {s['menu_hover']};
     }}

--- a/src/palette_themes.py
+++ b/src/palette_themes.py
@@ -1,10 +1,9 @@
 import hashlib
 import os
+import sys
 import tempfile
 
 from PyQt6.QtGui import QColor, QPalette
-
-from utils.utils import resource_path
 
 _GLYPH_NAMES = (
     "chevron_right",
@@ -16,14 +15,26 @@ _GLYPH_NAMES = (
 )
 
 
+def _asset_root() -> str:
+    """Resolve the assets directory regardless of cwd or PyInstaller bundling."""
+    if hasattr(sys, "_MEIPASS"):
+        return os.path.join(sys._MEIPASS, "assets")
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
 def _load_glyphs() -> dict:
     glyphs = {}
+    root = _asset_root()
     for name in _GLYPH_NAMES:
-        path = resource_path(os.path.join("theme", f"{name}.svg"))
+        path = os.path.join(root, "theme", f"{name}.svg")
         try:
             with open(path, "r", encoding="utf-8") as f:
-                glyphs[name] = f.read()
-        except OSError:
+                text = f.read()
+            if not text.strip():
+                raise OSError("empty SVG")
+            glyphs[name] = text
+        except OSError as e:
+            print(f"palette_themes: failed to load {path}: {e}", file=sys.stderr)
             glyphs[name] = ""
     return glyphs
 
@@ -34,13 +45,25 @@ _CACHE_DIR = os.path.join(tempfile.gettempdir(), "finalbigv2_theme")
 
 def _tinted_path(name: str, color: str) -> str:
     """Write a tinted SVG to a temp cache and return a forward-slash file URL."""
+    svg = _GLYPHS.get(name, "")
+    if not svg.strip():
+        return ""
     os.makedirs(_CACHE_DIR, exist_ok=True)
     digest = hashlib.md5(color.encode("ascii")).hexdigest()[:8]
     out = os.path.join(_CACHE_DIR, f"{name}_{digest}.svg")
-    if not os.path.exists(out):
-        tinted = _GLYPHS[name].replace("currentColor", color)
-        with open(out, "w", encoding="utf-8") as f:
+    needs_write = True
+    if os.path.exists(out):
+        try:
+            if os.path.getsize(out) > 0:
+                needs_write = False
+        except OSError:
+            pass
+    if needs_write:
+        tinted = svg.replace("currentColor", color)
+        tmp = out + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
             f.write(tinted)
+        os.replace(tmp, out)
     return out.replace("\\", "/")
 
 NORD = {

--- a/src/settings.py
+++ b/src/settings.py
@@ -136,6 +136,22 @@ class Settings:
         self.set_bool("settings/dark_mode", value)
 
     @property
+    def theme(self) -> str:
+        return self.get_str("settings/theme", "qdark")
+
+    @theme.setter
+    def theme(self, value: str) -> None:
+        self.set_str("settings/theme", value)
+
+    @property
+    def theme_density(self) -> int:
+        return self.get_int("settings/theme_density", -3)
+
+    @theme_density.setter
+    def theme_density(self, value: int) -> None:
+        self.set_int("settings/theme_density", value)
+
+    @property
     def encoding(self) -> str:
         return self.get_str("settings/encoding", "latin_1")
 
@@ -174,6 +190,22 @@ class Settings:
     @preview_enabled.setter
     def preview_enabled(self, value: bool) -> None:
         self.set_bool("settings/preview", value)
+
+    @property
+    def extract_overwrite_default(self) -> str:
+        return self.get_str("settings/extract_overwrite_default", "ask")
+
+    @extract_overwrite_default.setter
+    def extract_overwrite_default(self, value: str) -> None:
+        self.set_str("settings/extract_overwrite_default", value)
+
+    @property
+    def add_overwrite_default(self) -> str:
+        return self.get_str("settings/add_overwrite_default", "ask")
+
+    @add_overwrite_default.setter
+    def add_overwrite_default(self, value: str) -> None:
+        self.set_str("settings/add_overwrite_default", value)
 
     @property
     def smart_replace_enabled(self) -> bool:
@@ -281,25 +313,88 @@ class Settings:
             message,
         )
 
-    def toggle_dark_mode(self):
-        is_checked = self.main.dark_mode_action.isChecked()
-        self.dark_mode = is_checked
+    def theme_is_dark(self, theme: str = None) -> bool:
+        from palette_themes import PALETTE_THEMES
 
-        if is_checked:
-            qdarktheme.setup_theme("dark", corner_shape="sharp")
+        theme = theme if theme is not None else self.theme
+        if theme == "qdark":
+            return True
+        if theme == "qlight":
+            return False
+        if theme in PALETTE_THEMES:
+            return PALETTE_THEMES[theme][1]["is_dark"]
+        return theme.startswith("dark")
+
+    def apply_theme(self, theme: str = None):
+        from PyQt6.QtWidgets import QApplication
+
+        from palette_themes import PALETTE_THEMES, build_palette, build_stylesheet
+
+        theme = theme if theme is not None else self.theme
+        app = QApplication.instance()
+
+        if theme in ("qdark", "qlight"):
+            mode = "dark" if theme == "qdark" else "light"
+            if hasattr(qdarktheme, "setup_theme"):
+                qdarktheme.setup_theme(mode, corner_shape="sharp")
+            else:
+                app.setStyleSheet(qdarktheme.load_stylesheet(mode))
+        elif theme in PALETTE_THEMES:
+            _, scheme = PALETTE_THEMES[theme]
+            app.setStyleSheet("")
+            app.setPalette(build_palette(scheme))
+            app.setStyleSheet(build_stylesheet(scheme))
         else:
-            qdarktheme.setup_theme("light", corner_shape="sharp")
+            try:
+                from qt_material import apply_stylesheet
+                app_font = app.font()
+                apply_stylesheet(
+                    app,
+                    theme=theme,
+                    invert_secondary=theme.startswith("light"),
+                    extra={
+                        "density_scale": str(self.theme_density),
+                        "font_family": app_font.family(),
+                    },
+                )
+            except Exception as e:
+                QMessageBox.warning(
+                    self.main,
+                    "Theme Error",
+                    f"Failed to apply theme '{theme}': {e}\nFalling back to dark.",
+                )
+                self.theme = "qdark"
+                if hasattr(qdarktheme, "setup_theme"):
+                    qdarktheme.setup_theme("dark", corner_shape="sharp")
+                return
 
-        for x in range(self.main.tabs.count()):
-            widget: TextTab = self.main.tabs.widget(x)
-            if hasattr(widget, "text_widget"):
-                widget.text_widget.toggle_dark_mode(is_checked)
+        is_dark = self.theme_is_dark(theme)
+        self.dark_mode = is_dark
+        if hasattr(self.main, "tabs"):
+            for x in range(self.main.tabs.count()):
+                widget: TextTab = self.main.tabs.widget(x)
+                if hasattr(widget, "text_widget"):
+                    widget.text_widget.toggle_dark_mode(is_dark)
+
+    def set_theme(self, theme: str):
+        self.theme = theme
+        self.apply_theme(theme)
+
+    def set_theme_density(self, value: int):
+        self.theme_density = value
+        self.apply_theme()
 
     def toggle_external(self):
         self.external = self.main.use_external_action.isChecked()
 
     def toggle_smart_replace(self):
         self.smart_replace_enabled = self.main.smart_replace_action.isChecked()
+
+    def set_extract_overwrite_default(self, value: str):
+        self.extract_overwrite_default = value
+
+    def set_add_overwrite_default(self, value: str):
+        self.add_overwrite_default = value
 
     def set_default_file_list_type(self, view_type: str):
         """Set the default file list view type."""

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,9 +8,10 @@ from typing import TYPE_CHECKING, List
 import platformdirs
 import qdarktheme
 from PyQt6.QtCore import QSettings
-from PyQt6.QtWidgets import QInputDialog, QMessageBox
+from PyQt6.QtWidgets import QApplication, QInputDialog, QMessageBox
 
 from file_views import ListFileView
+from palette_themes import PALETTE_THEMES, build_palette, build_stylesheet
 from utils.utils import ENCODING_LIST, RECENT_FILES_MAX
 
 if TYPE_CHECKING:
@@ -329,8 +330,6 @@ class Settings:
         )
 
     def theme_is_dark(self, theme: str = None) -> bool:
-        from palette_themes import PALETTE_THEMES
-
         theme = theme if theme is not None else self.theme
         if theme == "qdark":
             return True
@@ -341,10 +340,6 @@ class Settings:
         return theme.startswith("dark")
 
     def apply_theme(self, theme: str = None):
-        from PyQt6.QtWidgets import QApplication
-
-        from palette_themes import PALETTE_THEMES, build_palette, build_stylesheet
-
         theme = theme if theme is not None else self.theme
         app = QApplication.instance()
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -144,14 +144,6 @@ class Settings:
         self.set_str("settings/theme", value)
 
     @property
-    def theme_density(self) -> int:
-        return self.get_int("settings/theme_density", -3)
-
-    @theme_density.setter
-    def theme_density(self, value: int) -> None:
-        self.set_int("settings/theme_density", value)
-
-    @property
     def encoding(self) -> str:
         return self.get_str("settings/encoding", "latin_1")
 
@@ -333,40 +325,21 @@ class Settings:
         theme = theme if theme is not None else self.theme
         app = QApplication.instance()
 
+        if theme not in ("qdark", "qlight") and theme not in PALETTE_THEMES:
+            theme = "qdark"
+            self.theme = "qdark"
+
         if theme in ("qdark", "qlight"):
             mode = "dark" if theme == "qdark" else "light"
             if hasattr(qdarktheme, "setup_theme"):
                 qdarktheme.setup_theme(mode, corner_shape="sharp")
             else:
                 app.setStyleSheet(qdarktheme.load_stylesheet(mode))
-        elif theme in PALETTE_THEMES:
+        else:
             _, scheme = PALETTE_THEMES[theme]
             app.setStyleSheet("")
             app.setPalette(build_palette(scheme))
             app.setStyleSheet(build_stylesheet(scheme))
-        else:
-            try:
-                from qt_material import apply_stylesheet
-                app_font = app.font()
-                apply_stylesheet(
-                    app,
-                    theme=theme,
-                    invert_secondary=theme.startswith("light"),
-                    extra={
-                        "density_scale": str(self.theme_density),
-                        "font_family": app_font.family(),
-                    },
-                )
-            except Exception as e:
-                QMessageBox.warning(
-                    self.main,
-                    "Theme Error",
-                    f"Failed to apply theme '{theme}': {e}\nFalling back to dark.",
-                )
-                self.theme = "qdark"
-                if hasattr(qdarktheme, "setup_theme"):
-                    qdarktheme.setup_theme("dark", corner_shape="sharp")
-                return
 
         is_dark = self.theme_is_dark(theme)
         self.dark_mode = is_dark
@@ -379,10 +352,6 @@ class Settings:
     def set_theme(self, theme: str):
         self.theme = theme
         self.apply_theme(theme)
-
-    def set_theme_density(self, value: int):
-        self.theme_density = value
-        self.apply_theme()
 
     def toggle_external(self):
         self.external = self.main.use_external_action.isChecked()

--- a/src/settings.py
+++ b/src/settings.py
@@ -2,6 +2,7 @@ import json
 import os
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from enum import StrEnum
 from typing import TYPE_CHECKING, List
 
 import platformdirs
@@ -15,6 +16,24 @@ from utils.utils import ENCODING_LIST, RECENT_FILES_MAX
 if TYPE_CHECKING:
     from main import MainWindow
     from tabs.text_tab import TextTab
+
+
+class OverwriteDefault(StrEnum):
+    ASK = "ask"
+    OVERWRITE = "overwrite"
+    SKIP = "skip"
+
+    @classmethod
+    def from_stored(cls, raw: str) -> "OverwriteDefault":
+        # Legacy values from before the menu was collapsed.
+        if raw in ("yes", "yes_to_all"):
+            return cls.OVERWRITE
+        if raw == "no":
+            return cls.SKIP
+        try:
+            return cls(raw)
+        except ValueError:
+            return cls.ASK
 
 
 def str_to_bool(value) -> bool:
@@ -184,20 +203,24 @@ class Settings:
         self.set_bool("settings/preview", value)
 
     @property
-    def extract_overwrite_default(self) -> str:
-        return self.get_str("settings/extract_overwrite_default", "ask")
+    def extract_overwrite_default(self) -> OverwriteDefault:
+        return OverwriteDefault.from_stored(
+            self.get_str("settings/extract_overwrite_default", OverwriteDefault.ASK.value)
+        )
 
     @extract_overwrite_default.setter
-    def extract_overwrite_default(self, value: str) -> None:
-        self.set_str("settings/extract_overwrite_default", value)
+    def extract_overwrite_default(self, value: OverwriteDefault) -> None:
+        self.set_str("settings/extract_overwrite_default", value.value)
 
     @property
-    def add_overwrite_default(self) -> str:
-        return self.get_str("settings/add_overwrite_default", "ask")
+    def add_overwrite_default(self) -> OverwriteDefault:
+        return OverwriteDefault.from_stored(
+            self.get_str("settings/add_overwrite_default", OverwriteDefault.ASK.value)
+        )
 
     @add_overwrite_default.setter
-    def add_overwrite_default(self, value: str) -> None:
-        self.set_str("settings/add_overwrite_default", value)
+    def add_overwrite_default(self, value: OverwriteDefault) -> None:
+        self.set_str("settings/add_overwrite_default", value.value)
 
     @property
     def smart_replace_enabled(self) -> bool:
@@ -359,10 +382,10 @@ class Settings:
     def toggle_smart_replace(self):
         self.smart_replace_enabled = self.main.smart_replace_action.isChecked()
 
-    def set_extract_overwrite_default(self, value: str):
+    def set_extract_overwrite_default(self, value: OverwriteDefault):
         self.extract_overwrite_default = value
 
-    def set_add_overwrite_default(self, value: str):
+    def set_add_overwrite_default(self, value: OverwriteDefault):
         self.add_overwrite_default = value
 
     def set_default_file_list_type(self, view_type: str):

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,18 +24,6 @@ class OverwriteDefault(StrEnum):
     OVERWRITE = "overwrite"
     SKIP = "skip"
 
-    @classmethod
-    def from_stored(cls, raw: str) -> "OverwriteDefault":
-        # Legacy values from before the menu was collapsed.
-        if raw in ("yes", "yes_to_all"):
-            return cls.OVERWRITE
-        if raw == "no":
-            return cls.SKIP
-        try:
-            return cls(raw)
-        except ValueError:
-            return cls.ASK
-
 
 def str_to_bool(value) -> bool:
     """Convert QSettings string/integer value to boolean."""
@@ -205,7 +193,7 @@ class Settings:
 
     @property
     def extract_overwrite_default(self) -> OverwriteDefault:
-        return OverwriteDefault.from_stored(
+        return OverwriteDefault(
             self.get_str("settings/extract_overwrite_default", OverwriteDefault.ASK.value)
         )
 
@@ -215,7 +203,7 @@ class Settings:
 
     @property
     def add_overwrite_default(self) -> OverwriteDefault:
-        return OverwriteDefault.from_stored(
+        return OverwriteDefault(
             self.get_str("settings/add_overwrite_default", OverwriteDefault.ASK.value)
         )
 

--- a/src/tabs/generic_tab.py
+++ b/src/tabs/generic_tab.py
@@ -77,6 +77,7 @@ class GenericTab(QWidget):
 
         self.unsaved = True
         self.main.tabs.setTabText(self.main.tabs.currentIndex(), unsaved_name(self.name))
+        self.main.update_archive_name()
 
     def save(self):
         if not self.unsaved:
@@ -84,6 +85,7 @@ class GenericTab(QWidget):
 
         self.unsaved = False
         self.main.tabs.setTabText(self.main.tabs.currentIndex(), self.name)
+        self.main.update_archive_name()
 
     def search(self):
         pass

--- a/src/ui.py
+++ b/src/ui.py
@@ -35,12 +35,16 @@ class HasUiElements:
     workspace_menu: QMenu
     undo_action: QAction
     redo_action: QAction
-    dark_mode_action: QAction
+    theme_menu: QMenu
+    theme_scaling_menu: QMenu
+    material_themes_menu: QMenu
     use_external_action: QAction
     large_archive_action: QAction
     smart_replace_action: QAction
     preview_action: QAction
     default_view_menu: QMenu
+    extract_overwrite_menu: QMenu
+    add_overwrite_menu: QMenu
     lock_exceptions: list
 
 
@@ -221,12 +225,87 @@ def create_menu(main: "MainWindow"):
 
     option_menu.addSeparator()
 
-    main.dark_mode_action = QAction("&Dark Mode?", main, checkable=True)
-    main.dark_mode_action.setToolTip("Whether to use dark mode or not")
-    main.dark_mode_action.setChecked(main.settings.dark_mode)
-    main.dark_mode_action.triggered.connect(main.settings.toggle_dark_mode)
-    option_menu.addAction(main.dark_mode_action)
-    main.lock_exceptions.append(main.dark_mode_action)
+    main.theme_menu = QMenu("&Theme", main)
+    main.theme_menu.setToolTip("Application color theme")
+    option_menu.addMenu(main.theme_menu)
+    main.lock_exceptions.append(main.theme_menu)
+
+    theme_group = QActionGroup(main)
+    theme_group.setExclusive(True)
+    current_theme = main.settings.theme
+
+    from palette_themes import PALETTE_THEMES
+
+    top_entries = [("Dark (default)", "qdark"), ("Light", "qlight")]
+    for key, (label, _scheme) in PALETTE_THEMES.items():
+        top_entries.append((label, key))
+
+    for label, value in top_entries:
+        action = QAction(label, main, checkable=True)
+        action.setData(value)
+        action.setChecked(current_theme == value)
+        action.triggered.connect(lambda _, v=value: main.settings.set_theme(v))
+        theme_group.addAction(action)
+        main.theme_menu.addAction(action)
+        main.lock_exceptions.append(action)
+
+    try:
+        from qt_material import list_themes
+        qm_themes = sorted(list_themes())
+    except Exception:
+        qm_themes = []
+
+    if qm_themes:
+        main.theme_menu.addSeparator()
+        main.material_themes_menu = QMenu("&Material Design", main)
+        main.material_themes_menu.setToolTip("qt-material Material Design themes")
+        main.theme_menu.addMenu(main.material_themes_menu)
+        main.lock_exceptions.append(main.material_themes_menu)
+
+        def _label(t: str) -> str:
+            base = t[:-4] if t.endswith(".xml") else t
+            return base.replace("_", " ").title()
+
+        dark_themes = [t for t in qm_themes if t.startswith("dark")]
+        light_themes = [t for t in qm_themes if t.startswith("light")]
+        other_themes = [t for t in qm_themes if t not in dark_themes and t not in light_themes]
+
+        for t in dark_themes + light_themes + other_themes:
+            action = QAction(_label(t), main, checkable=True)
+            action.setData(t)
+            action.setChecked(current_theme == t)
+            action.triggered.connect(lambda _, v=t: main.settings.set_theme(v))
+            theme_group.addAction(action)
+            main.material_themes_menu.addAction(action)
+            main.lock_exceptions.append(action)
+
+    main.theme_menu.addSeparator()
+
+    main.theme_scaling_menu = QMenu("Theme &Scaling", main)
+    main.theme_scaling_menu.setToolTip(
+        "Density scale for qt-material themes (lower = more compact). No effect on Dark/Light."
+    )
+    main.theme_menu.addMenu(main.theme_scaling_menu)
+    main.lock_exceptions.append(main.theme_scaling_menu)
+
+    density_group = QActionGroup(main)
+    density_group.setExclusive(True)
+    density_options = [
+        ("Compact (-4)", -4),
+        ("Tight (-3, default)", -3),
+        ("Normal (-2)", -2),
+        ("Comfortable (-1)", -1),
+        ("Spacious (0)", 0),
+    ]
+    current_density = main.settings.theme_density
+    for label, value in density_options:
+        action = QAction(label, main, checkable=True)
+        action.setData(value)
+        action.setChecked(current_density == value)
+        action.triggered.connect(lambda _, v=value: main.settings.set_theme_density(v))
+        density_group.addAction(action)
+        main.theme_scaling_menu.addAction(action)
+        main.lock_exceptions.append(action)
 
     main.use_external_action = QAction("Use &External Programs?", main, checkable=True)
     main.use_external_action.setToolTip(
@@ -261,6 +340,53 @@ def create_menu(main: "MainWindow"):
     main.preview_action.triggered.connect(main.settings.toggle_preview)
     option_menu.addAction(main.preview_action)
     main.lock_exceptions.append(main.preview_action)
+
+    overwrite_options = [
+        ("Ask", "ask"),
+        ("Yes", "yes"),
+        ("No", "no"),
+        ("Yes to All", "yes_to_all"),
+    ]
+
+    main.extract_overwrite_menu = QMenu("&Extract Overwrite Default", main)
+    main.extract_overwrite_menu.setToolTip(
+        "Default response when extracting a file that already exists in the destination archive"
+    )
+    option_menu.addMenu(main.extract_overwrite_menu)
+    main.lock_exceptions.append(main.extract_overwrite_menu)
+
+    extract_overwrite_group = QActionGroup(main)
+    extract_overwrite_group.setExclusive(True)
+    for label, value in overwrite_options:
+        action = QAction(label, main, checkable=True)
+        action.setData(value)
+        action.setChecked(main.settings.extract_overwrite_default == value)
+        action.triggered.connect(
+            lambda _, v=value: main.settings.set_extract_overwrite_default(v)
+        )
+        extract_overwrite_group.addAction(action)
+        main.extract_overwrite_menu.addAction(action)
+        main.lock_exceptions.append(action)
+
+    main.add_overwrite_menu = QMenu("&Add Overwrite Default", main)
+    main.add_overwrite_menu.setToolTip(
+        "Default response when adding a file whose name already exists in the archive"
+    )
+    option_menu.addMenu(main.add_overwrite_menu)
+    main.lock_exceptions.append(main.add_overwrite_menu)
+
+    add_overwrite_group = QActionGroup(main)
+    add_overwrite_group.setExclusive(True)
+    for label, value in overwrite_options:
+        action = QAction(label, main, checkable=True)
+        action.setData(value)
+        action.setChecked(main.settings.add_overwrite_default == value)
+        action.triggered.connect(
+            lambda _, v=value: main.settings.set_add_overwrite_default(v)
+        )
+        add_overwrite_group.addAction(action)
+        main.add_overwrite_menu.addAction(action)
+        main.lock_exceptions.append(action)
 
     main.default_view_menu = QMenu("Default File &View", main)
     main.default_view_menu.setToolTip("Select the default view type when creating new file lists")

--- a/src/ui.py
+++ b/src/ui.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
 
 from file_views import FileViewTabs, ListFileView, file_view_mapping
 from misc import SearchBox, TabWidget
+from settings import OverwriteDefault
 from utils.utils import resource_path
 
 if TYPE_CHECKING:
@@ -282,10 +283,9 @@ def create_menu(main: "MainWindow"):
     main.lock_exceptions.append(main.preview_action)
 
     overwrite_options = [
-        ("Ask", "ask"),
-        ("Yes", "yes"),
-        ("No", "no"),
-        ("Yes to All", "yes_to_all"),
+        ("Ask", OverwriteDefault.ASK),
+        ("Overwrite", OverwriteDefault.OVERWRITE),
+        ("Skip", OverwriteDefault.SKIP),
     ]
 
     main.extract_overwrite_menu = QMenu("&Extract Overwrite Default", main)

--- a/src/ui.py
+++ b/src/ui.py
@@ -15,6 +15,7 @@ from PyQt6.QtWidgets import (
 
 from file_views import FileViewTabs, ListFileView, file_view_mapping
 from misc import SearchBox, TabWidget
+from palette_themes import PALETTE_THEMES
 from settings import OverwriteDefault
 from utils.utils import resource_path
 
@@ -232,8 +233,6 @@ def create_menu(main: "MainWindow"):
     theme_group = QActionGroup(main)
     theme_group.setExclusive(True)
     current_theme = main.settings.theme
-
-    from palette_themes import PALETTE_THEMES
 
     top_entries = [("Dark (default)", "qdark"), ("Light", "qlight")]
     for key, (label, _scheme) in PALETTE_THEMES.items():

--- a/src/ui.py
+++ b/src/ui.py
@@ -217,6 +217,7 @@ def create_menu(main: "MainWindow"):
     search_achive_regex_action.setShortcut(QKeySequence("ALT+SHIFT+F"))
 
     option_menu = menu.addMenu("&Help")
+    option_menu.setToolTipsVisible(True)
     main.lock_exceptions.append(option_menu.addAction("&About", main.show_about))
 
     help_action = option_menu.addAction("&Help", main.show_help)

--- a/src/ui.py
+++ b/src/ui.py
@@ -36,8 +36,6 @@ class HasUiElements:
     undo_action: QAction
     redo_action: QAction
     theme_menu: QMenu
-    theme_scaling_menu: QMenu
-    material_themes_menu: QMenu
     use_external_action: QAction
     large_archive_action: QAction
     smart_replace_action: QAction
@@ -247,64 +245,6 @@ def create_menu(main: "MainWindow"):
         action.triggered.connect(lambda _, v=value: main.settings.set_theme(v))
         theme_group.addAction(action)
         main.theme_menu.addAction(action)
-        main.lock_exceptions.append(action)
-
-    try:
-        from qt_material import list_themes
-        qm_themes = sorted(list_themes())
-    except Exception:
-        qm_themes = []
-
-    if qm_themes:
-        main.theme_menu.addSeparator()
-        main.material_themes_menu = QMenu("&Material Design", main)
-        main.material_themes_menu.setToolTip("qt-material Material Design themes")
-        main.theme_menu.addMenu(main.material_themes_menu)
-        main.lock_exceptions.append(main.material_themes_menu)
-
-        def _label(t: str) -> str:
-            base = t[:-4] if t.endswith(".xml") else t
-            return base.replace("_", " ").title()
-
-        dark_themes = [t for t in qm_themes if t.startswith("dark")]
-        light_themes = [t for t in qm_themes if t.startswith("light")]
-        other_themes = [t for t in qm_themes if t not in dark_themes and t not in light_themes]
-
-        for t in dark_themes + light_themes + other_themes:
-            action = QAction(_label(t), main, checkable=True)
-            action.setData(t)
-            action.setChecked(current_theme == t)
-            action.triggered.connect(lambda _, v=t: main.settings.set_theme(v))
-            theme_group.addAction(action)
-            main.material_themes_menu.addAction(action)
-            main.lock_exceptions.append(action)
-
-    main.theme_menu.addSeparator()
-
-    main.theme_scaling_menu = QMenu("Theme &Scaling", main)
-    main.theme_scaling_menu.setToolTip(
-        "Density scale for qt-material themes (lower = more compact). No effect on Dark/Light."
-    )
-    main.theme_menu.addMenu(main.theme_scaling_menu)
-    main.lock_exceptions.append(main.theme_scaling_menu)
-
-    density_group = QActionGroup(main)
-    density_group.setExclusive(True)
-    density_options = [
-        ("Compact (-4)", -4),
-        ("Tight (-3, default)", -3),
-        ("Normal (-2)", -2),
-        ("Comfortable (-1)", -1),
-        ("Spacious (0)", 0),
-    ]
-    current_density = main.settings.theme_density
-    for label, value in density_options:
-        action = QAction(label, main, checkable=True)
-        action.setData(value)
-        action.setChecked(current_density == value)
-        action.triggered.connect(lambda _, v=value: main.settings.set_theme_density(v))
-        density_group.addAction(action)
-        main.theme_scaling_menu.addAction(action)
         main.lock_exceptions.append(action)
 
     main.use_external_action = QAction("Use &External Programs?", main, checkable=True)


### PR DESCRIPTION
## Summary

- **Per-dialog overwrite defaults** — Two new submenus under Options ("Extract Overwrite Default" and "Add Overwrite Default") let you preset Ask / Yes / No / Yes to All for the file-exists confirmation prompts. Setting anything other than Ask skips the dialog entirely and auto-applies your choice.
- **Unsaved-changes window title** — The title bar now shows a `*` prefix whenever the archive has pending modifications (`archive.modified_entries`) or any open editor tab is unsaved. Refreshes on add/delete/rename/undo/redo/save/merge/folder-add.
- **Theme system** — Replaces the single "Dark Mode?" checkbox with a Theme menu:
  - Dark (default), Light — existing pyqtdarktheme
  - **Nord, Solarized Dark, Solarized Light, Dracula, Gruvbox Dark** — hand-rolled `QPalette` + targeted `QSS` (new `src/palette_themes.py`)
  - **Material Design ▶** submenu — all 26 qt-material themes (`dark_blue.xml`, `light_amber.xml`, …)
  - **Theme Scaling ▶** submenu — density presets (-4 to 0) for qt-material themes; default Tight (-3)
- Editor syntax-highlighting dark/light flag now derives from the active theme rather than the separate dark-mode toggle.

## Files changed

- `requirements.txt` — adds `qt-material`
- `src/main.py` — startup uses `settings.apply_theme()`; title refresh hooks; overwrite-default plumbing; folder-add title refresh
- `src/settings.py` — new `theme`, `theme_density`, `extract_overwrite_default`, `add_overwrite_default` settings; centralized `apply_theme()` handling all three theme backends
- `src/ui.py` — Theme menu (top-level palette themes + Dark/Light, nested Material Design submenu, Theme Scaling submenu); two Overwrite Default submenus
- `src/tabs/generic_tab.py` — `become_unsaved`/`save` notify the main window to refresh the title
- `src/palette_themes.py` *(new)* — Nord/Solarized/Dracula/Gruvbox palette dicts and `build_palette()` / `build_stylesheet()` helpers

## Test plan

- [ ] Toggle each theme; verify menus, tabs, scrollbars, buttons, text inputs all themed
- [ ] Switch between dark and light palette themes; confirm editor syntax colors flip correctly
- [ ] Set Extract Overwrite Default to each option; extract a conflicting file and verify dialog behavior matches
- [ ] Set Add Overwrite Default to each option; drag-drop a duplicate file and verify
- [ ] Make any archive edit; confirm \`*\` appears in window title
- [ ] Save the archive; confirm \`*\` disappears
- [ ] Edit a text tab; confirm \`*\` appears even before saving the archive
- [ ] Drag-drop a folder containing duplicates; confirm \`*\` appears and the configured overwrite default applies
- [ ] Change Theme Scaling preset; confirm only padding shifts, no crash