### PR TITLE
Summarize files added and overwritten after adds

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import traceback
 import urllib.parse
 import webbrowser
 from datetime import datetime
+from enum import Enum, auto
 from typing import TYPE_CHECKING, cast
 
 import moddb
@@ -111,6 +112,29 @@ def handle_exception(exc_type, exc_value, exc_traceback):
 
 
 sys.excepthook = handle_exception
+
+
+class AddOutcome(Enum):
+    """What actually happened to the archive when adding a single file.
+
+    Reported by ``add_file_to_archive`` itself, which is the only place that
+    knows whether an existing entry was replaced or the write was skipped or
+    failed. Callers must not infer this from the dialog button.
+
+    ``OVERWRITTEN_ALL`` is an overwrite where the user also asked to apply the
+    choice to every following file ("Yes to All"); loops use it to stop
+    prompting, keeping the Qt button enum out of caller code.
+    """
+
+    NEW = auto()
+    OVERWRITTEN = auto()
+    OVERWRITTEN_ALL = auto()
+    SKIPPED = auto()
+    FAILED = auto()
+
+    @property
+    def overwrote(self) -> bool:
+        return self in (AddOutcome.OVERWRITTEN, AddOutcome.OVERWRITTEN_ALL)
 
 
 class MainWindow(QMainWindow, HasUiElements, SearchManager):
@@ -870,25 +894,9 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 files = filtered_files
                 complete_component = f"{component}\\{complete_component}"
 
-        if ask_name:
-            name, ok = WrappingInputDialog.getText(
-                self,
-                "Filename",
-                "Save the file under the following name:",
-                name,
-            )
-            if not ok or not name:
-                return False
-
-        ret = self.add_file_to_archive(url, name, blank, skip_all=not ask_name)
-        if ret != QMessageBox.StandardButton.No:
-            self.listwidget.add_files([name])
-            self.refresh_tabs([name])
-
-        if show_summary:
-            new, overwritten = self._classify_add(ret)
-            self._show_add_summary(new, [name] if overwritten else [])
-        return ret
+        return self._add_resolved(
+            url, name, blank=blank, ask_name=ask_name, show_summary=show_summary
+        )
 
     def _add_file_with_name(
         self, url, suggested_name, *, blank=False, ask_name=True, show_summary=True
@@ -896,8 +904,15 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         """Add a file to archive with a pre-suggested name
         (e.g., from drag-drop between archives).
         """
-        name = suggested_name
+        return self._add_resolved(
+            url, suggested_name, blank=blank, ask_name=ask_name, show_summary=show_summary
+        )
 
+    def _add_resolved(self, url, name, *, blank=False, ask_name=True, show_summary=True):
+        """Add a single file under a resolved ``name``, optionally prompting for it.
+
+        Returns the :class:`AddOutcome` for the add.
+        """
         if ask_name:
             name, ok = WrappingInputDialog.getText(
                 self,
@@ -906,17 +921,16 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 name,
             )
             if not ok or not name:
-                return False
+                return AddOutcome.SKIPPED
 
-        ret = self.add_file_to_archive(url, name, blank, skip_all=not ask_name)
-        if ret != QMessageBox.StandardButton.No:
+        outcome = self.add_file_to_archive(url, name, blank, skip_all=not ask_name)
+        if outcome is AddOutcome.NEW or outcome.overwrote:
             self.listwidget.add_files([name])
             self.refresh_tabs([name])
 
         if show_summary:
-            new, overwritten = self._classify_add(ret)
-            self._show_add_summary(new, [name] if overwritten else [])
-        return ret
+            self._show_add_summary(*self._tally(outcome, name))
+        return outcome
 
     def _add_folder(self, url, *, show_summary=True):
         skip_all = False
@@ -928,19 +942,17 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             for f in files:
                 full_path = os.path.join(root, f)
                 name = normalize_name(os.path.relpath(full_path, common_dir))
-                ret = self.add_file_to_archive(
+                outcome = self.add_file_to_archive(
                     full_path, name, blank=False, skip_all=skip_all, undoable=False
                 )
 
-                if ret != QMessageBox.StandardButton.No:
+                new, overwritten = self._tally(outcome, name)
+                new_count += new
+                overwritten_names.extend(overwritten)
+                if new or overwritten:
                     files_to_add.append(name)
 
-                new, overwritten = self._classify_add(ret)
-                new_count += new
-                if overwritten:
-                    overwritten_names.append(name)
-
-                if ret == QMessageBox.StandardButton.YesToAll:
+                if outcome is AddOutcome.OVERWRITTEN_ALL:
                     skip_all = True
 
         self.listwidget.add_files(files_to_add)
@@ -950,16 +962,22 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         return new_count, overwritten_names
 
     def add_file_to_archive(self, url, name, blank=False, skip_all=False, undoable=True):
+        """Add ``url`` to the archive as ``name``.
+
+        Returns an :class:`AddOutcome` describing what actually happened to the
+        archive. ``OVERWRITTEN_ALL`` additionally tells loops to stop prompting.
+        """
         replaced_data = None
-        ret = None
-        if self.archive.file_exists(name):
+        overwrite_all = skip_all
+        existed = self.archive.file_exists(name)
+        if existed:
             replaced_data = self.archive.read_file(name)
             if not skip_all:
                 default = self.settings.add_overwrite_default
                 if default is OverwriteDefault.SKIP:
-                    return QMessageBox.StandardButton.No
+                    return AddOutcome.SKIPPED
                 if default is OverwriteDefault.OVERWRITE:
-                    ret = QMessageBox.StandardButton.YesToAll
+                    overwrite_all = True
                 else:
                     ret = QMessageBox.question(
                         self,
@@ -971,7 +989,8 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                         QMessageBox.StandardButton.No,
                     )
                     if ret == QMessageBox.StandardButton.No:
-                        return ret
+                        return AddOutcome.SKIPPED
+                    overwrite_all = ret == QMessageBox.StandardButton.YesToAll
 
             self.archive.remove_file(name)
 
@@ -983,27 +1002,24 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                     self.archive.add_file(name, f.read())
         except Exception as e:
             QMessageBox.warning(self, "Error", str(e))
-            return ret
+            return AddOutcome.FAILED
 
         if undoable:
             self.undo_stack.push(AddFileCommand(name, self.archive.read_file(name), replaced_data))
             self.update_undo_redo_actions()
 
-        return ret
+        if not existed:
+            return AddOutcome.NEW
+        return AddOutcome.OVERWRITTEN_ALL if overwrite_all else AddOutcome.OVERWRITTEN
 
     @staticmethod
-    def _classify_add(ret) -> tuple[int, int]:
-        """Map an add_file_to_archive return value to (new, overwritten) counts.
-
-        ``None`` means a new file was added; ``Yes``/``YesToAll`` means an
-        existing file was overwritten; ``No`` (skipped) and ``False`` (rename
-        cancelled) mean nothing was added.
-        """
-        if ret is False or ret == QMessageBox.StandardButton.No:
-            return 0, 0
-        if ret is None:
-            return 1, 0
-        return 0, 1
+    def _tally(outcome: AddOutcome, name: str) -> tuple[int, list[str]]:
+        """Map one add's outcome to a ``(new_count, overwritten_names)`` pair."""
+        if outcome is AddOutcome.NEW:
+            return 1, []
+        if outcome.overwrote:
+            return 0, [name]
+        return 0, []
 
     def _show_add_summary(self, new_count: int, overwritten_names: list[str]) -> None:
         overwritten_count = len(overwritten_names)
@@ -1407,25 +1423,22 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
             if os.path.isfile(local_file):
                 suggested_name = original_paths.get(os.path.normpath(local_file))
-                ret = (
+                outcome = (
                     self._add_file_with_name(
                         local_file, suggested_name, ask_name=False, show_summary=False
                     )
                     if suggested_name
                     else self._add_file(local_file, ask_name=not yes_to_all, show_summary=False)
                 )
-                new, overwritten = self._classify_add(ret)
+                new, names = self._tally(outcome, suggested_name or normalize_name(local_file))
                 new_count += new
-                if overwritten:
-                    overwritten_names.append(suggested_name or normalize_name(local_file))
+                overwritten_names.extend(names)
+                if outcome is AddOutcome.OVERWRITTEN_ALL:
+                    yes_to_all = True
             else:
                 new, names = self._add_folder(local_file, show_summary=False)
                 new_count += new
                 overwritten_names.extend(names)
-                ret = None
-
-            if ret == QMessageBox.StandardButton.YesToAll:
-                yes_to_all = True
 
         self._show_add_summary(new_count, overwritten_names)
         event.acceptProposedAction()

--- a/src/main.py
+++ b/src/main.py
@@ -913,7 +913,9 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
     def _add_resolved(self, url, name, *, blank=False, ask_name=True, show_summary=True):
         """Add a single file under a resolved ``name``, optionally prompting for it.
 
-        Returns the :class:`AddOutcome` for the add.
+        Returns ``(outcome, name)`` where ``name`` is the name the file was
+        actually stored under (after the rename prompt), so callers report the
+        real entry rather than the name they passed in.
         """
         if ask_name:
             name, ok = WrappingInputDialog.getText(
@@ -923,7 +925,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 name,
             )
             if not ok or not name:
-                return AddOutcome.SKIPPED
+                return AddOutcome.SKIPPED, name
 
         outcome = self.add_file_to_archive(url, name, blank, skip_all=not ask_name)
         if outcome is AddOutcome.NEW or outcome.overwrote:
@@ -932,7 +934,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
         if show_summary:
             self._show_add_summary(*self._tally(outcome, name))
-        return outcome
+        return outcome, name
 
     def _add_folder(self, url, *, show_summary=True):
         skip_all = False
@@ -1416,14 +1418,14 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
             if os.path.isfile(local_file):
                 suggested_name = original_paths.get(os.path.normpath(local_file))
-                outcome = (
+                outcome, name = (
                     self._add_file_with_name(
                         local_file, suggested_name, ask_name=False, show_summary=False
                     )
                     if suggested_name
                     else self._add_file(local_file, ask_name=not yes_to_all, show_summary=False)
                 )
-                new, names = self._tally(outcome, suggested_name or normalize_name(local_file))
+                new, names = self._tally(outcome, name)
                 new_names.extend(new)
                 overwritten_names.extend(names)
                 if outcome is AddOutcome.OVERWRITTEN_ALL:

--- a/src/main.py
+++ b/src/main.py
@@ -703,12 +703,16 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
         files.reverse()
         files_added = []
+        overwritten_names = []
         for file in files:
-            files_added.extend(self._merge_archives(file))
+            added, overwritten = self._merge_archives(file)
+            files_added.extend(added)
+            overwritten_names.extend(overwritten)
 
         self.settings.last_dir = os.path.dirname(files[0])
         self.listwidget.add_files(files_added)
         self.update_archive_name()
+        self._show_add_summary(len(files_added) - len(overwritten_names), overwritten_names)
 
     def _merge_archives(self, path):
         if self.settings.large_archive:
@@ -719,6 +723,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
         skip_all = False
         files_added = []
+        overwritten_names = []
         files = archive.file_list()
         length = len(files)
         text_box = QMessageBox(
@@ -739,6 +744,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 f"File: ({index + 1}/{length})<br>Processing: <b>{file}</b>"
             )
             QApplication.processEvents()
+            overwrote = False
             if self.archive.file_exists(file):
                 default = (
                     OverwriteDefault.OVERWRITE
@@ -763,10 +769,13 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                         skip_all = True
 
                 self.archive.remove_file(file)
+                overwrote = True
 
             self.archive.add_file(file, archive.read_file(file))
 
             files_added.append(file)
+            if overwrote:
+                overwritten_names.append(file)
 
             size = self.archive.archive_memory_size()
             if size > 524288000:
@@ -789,7 +798,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         )
         text_box.accept()
 
-        return files_added
+        return files_added, overwritten_names
 
     def new(self):
         self._new()
@@ -843,7 +852,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
     def new_file(self):
         self._add_file(None, blank=True)
 
-    def _add_file(self, url, *, blank=False, ask_name=True):
+    def _add_file(self, url, *, blank=False, ask_name=True, show_summary=True):
         name = normalize_name(url)
         if self.settings.smart_replace_enabled:
             files = self.archive.file_list()
@@ -876,9 +885,14 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             self.listwidget.add_files([name])
             self.refresh_tabs([name])
 
+        if show_summary:
+            new, overwritten = self._classify_add(ret)
+            self._show_add_summary(new, [name] if overwritten else [])
         return ret
 
-    def _add_file_with_name(self, url, suggested_name, *, blank=False, ask_name=True):
+    def _add_file_with_name(
+        self, url, suggested_name, *, blank=False, ask_name=True, show_summary=True
+    ):
         """Add a file to archive with a pre-suggested name
         (e.g., from drag-drop between archives).
         """
@@ -899,12 +913,17 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             self.listwidget.add_files([name])
             self.refresh_tabs([name])
 
+        if show_summary:
+            new, overwritten = self._classify_add(ret)
+            self._show_add_summary(new, [name] if overwritten else [])
         return ret
 
-    def _add_folder(self, url):
+    def _add_folder(self, url, *, show_summary=True):
         skip_all = False
         common_dir = os.path.dirname(url)
         files_to_add = []
+        new_count = 0
+        overwritten_names = []
         for root, _, files in os.walk(url):
             for f in files:
                 full_path = os.path.join(root, f)
@@ -916,11 +935,19 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 if ret != QMessageBox.StandardButton.No:
                     files_to_add.append(name)
 
+                new, overwritten = self._classify_add(ret)
+                new_count += new
+                if overwritten:
+                    overwritten_names.append(name)
+
                 if ret == QMessageBox.StandardButton.YesToAll:
                     skip_all = True
 
         self.listwidget.add_files(files_to_add)
         self.update_archive_name()
+        if show_summary:
+            self._show_add_summary(new_count, overwritten_names)
+        return new_count, overwritten_names
 
     def add_file_to_archive(self, url, name, blank=False, skip_all=False, undoable=True):
         replaced_data = None
@@ -963,6 +990,35 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             self.update_undo_redo_actions()
 
         return ret
+
+    @staticmethod
+    def _classify_add(ret) -> tuple[int, int]:
+        """Map an add_file_to_archive return value to (new, overwritten) counts.
+
+        ``None`` means a new file was added; ``Yes``/``YesToAll`` means an
+        existing file was overwritten; ``No`` (skipped) and ``False`` (rename
+        cancelled) mean nothing was added.
+        """
+        if ret is False or ret == QMessageBox.StandardButton.No:
+            return 0, 0
+        if ret is None:
+            return 1, 0
+        return 0, 1
+
+    def _show_add_summary(self, new_count: int, overwritten_names: list[str]) -> None:
+        overwritten_count = len(overwritten_names)
+        total = new_count + overwritten_count
+        if total == 0:
+            return
+        box = QMessageBox(
+            QMessageBox.Icon.Information,
+            "Files added",
+            f"Added {total} file(s) — {new_count} new, {overwritten_count} overwritten.",
+            parent=self,
+        )
+        if overwritten_names:
+            box.setDetailedText("Overwritten files:\n" + "\n".join(overwritten_names))
+        box.exec()
 
     def is_file_selected(self):
         if not self.listwidget.active_list.is_file_selected():
@@ -1337,6 +1393,8 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 original_paths[os.path.normpath(temp)] = original
 
         yes_to_all = False
+        new_count = 0
+        overwritten_names = []
         for url in md.urls():
             local_file = url.toLocalFile()
 
@@ -1350,16 +1408,26 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             if os.path.isfile(local_file):
                 suggested_name = original_paths.get(os.path.normpath(local_file))
                 ret = (
-                    self._add_file_with_name(local_file, suggested_name, ask_name=False)
+                    self._add_file_with_name(
+                        local_file, suggested_name, ask_name=False, show_summary=False
+                    )
                     if suggested_name
-                    else self._add_file(local_file, ask_name=not yes_to_all)
+                    else self._add_file(local_file, ask_name=not yes_to_all, show_summary=False)
                 )
+                new, overwritten = self._classify_add(ret)
+                new_count += new
+                if overwritten:
+                    overwritten_names.append(suggested_name or normalize_name(local_file))
             else:
-                ret = self._add_folder(local_file)
+                new, names = self._add_folder(local_file, show_summary=False)
+                new_count += new
+                overwritten_names.extend(names)
+                ret = None
 
             if ret == QMessageBox.StandardButton.YesToAll:
                 yes_to_all = True
 
+        self._show_add_summary(new_count, overwritten_names)
         event.acceptProposedAction()
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,7 @@ from PyQt6.QtWidgets import (
 )
 
 from file_views import get_file_view_class
-from misc import NewTabDialog, WrappingInputDialog
+from misc import AddSummaryDialog, NewTabDialog, WrappingInputDialog
 from search import SearchManager
 from settings import FileTab, FileView, OverwriteDefault, Settings, Workplace
 from tabs import get_tab_from_file_type
@@ -726,17 +726,17 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
             return
 
         files.reverse()
-        files_added = []
+        new_names = []
         overwritten_names = []
         for file in files:
-            added, overwritten = self._merge_archives(file)
-            files_added.extend(added)
+            new, overwritten = self._merge_archives(file)
+            new_names.extend(new)
             overwritten_names.extend(overwritten)
 
         self.settings.last_dir = os.path.dirname(files[0])
-        self.listwidget.add_files(files_added)
+        self.listwidget.add_files(new_names + overwritten_names)
         self.update_archive_name()
-        self._show_add_summary(len(files_added) - len(overwritten_names), overwritten_names)
+        self._show_add_summary(new_names, overwritten_names)
 
     def _merge_archives(self, path):
         if self.settings.large_archive:
@@ -746,7 +746,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 archive = InMemoryArchive(f.read())
 
         skip_all = False
-        files_added = []
+        new_names = []
         overwritten_names = []
         files = archive.file_list()
         length = len(files)
@@ -797,9 +797,10 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
 
             self.archive.add_file(file, archive.read_file(file))
 
-            files_added.append(file)
             if overwrote:
                 overwritten_names.append(file)
+            else:
+                new_names.append(file)
 
             size = self.archive.archive_memory_size()
             if size > 524288000:
@@ -818,11 +819,12 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                     break
 
         text_box.setText(
-            f"Finished processing archive: <b>{path}</b><br>Added {len(files_added)} files"
+            f"Finished processing archive: <b>{path}</b><br>"
+            f"Added {len(new_names) + len(overwritten_names)} files"
         )
         text_box.accept()
 
-        return files_added, overwritten_names
+        return new_names, overwritten_names
 
     def new(self):
         self._new()
@@ -935,8 +937,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
     def _add_folder(self, url, *, show_summary=True):
         skip_all = False
         common_dir = os.path.dirname(url)
-        files_to_add = []
-        new_count = 0
+        new_names = []
         overwritten_names = []
         for root, _, files in os.walk(url):
             for f in files:
@@ -947,19 +948,17 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 )
 
                 new, overwritten = self._tally(outcome, name)
-                new_count += new
+                new_names.extend(new)
                 overwritten_names.extend(overwritten)
-                if new or overwritten:
-                    files_to_add.append(name)
 
                 if outcome is AddOutcome.OVERWRITTEN_ALL:
                     skip_all = True
 
-        self.listwidget.add_files(files_to_add)
+        self.listwidget.add_files(new_names + overwritten_names)
         self.update_archive_name()
         if show_summary:
-            self._show_add_summary(new_count, overwritten_names)
-        return new_count, overwritten_names
+            self._show_add_summary(new_names, overwritten_names)
+        return new_names, overwritten_names
 
     def add_file_to_archive(self, url, name, blank=False, skip_all=False, undoable=True):
         """Add ``url`` to the archive as ``name``.
@@ -1013,28 +1012,22 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
         return AddOutcome.OVERWRITTEN_ALL if overwrite_all else AddOutcome.OVERWRITTEN
 
     @staticmethod
-    def _tally(outcome: AddOutcome, name: str) -> tuple[int, list[str]]:
-        """Map one add's outcome to a ``(new_count, overwritten_names)`` pair."""
+    def _tally(outcome: AddOutcome, name: str) -> tuple[list[str], list[str]]:
+        """Map one add's outcome to a ``(new_names, overwritten_names)`` pair."""
         if outcome is AddOutcome.NEW:
-            return 1, []
+            return [name], []
         if outcome.overwrote:
-            return 0, [name]
-        return 0, []
+            return [], [name]
+        return [], []
 
-    def _show_add_summary(self, new_count: int, overwritten_names: list[str]) -> None:
-        overwritten_count = len(overwritten_names)
-        total = new_count + overwritten_count
+    def _show_add_summary(self, new_names: list[str], overwritten_names: list[str]) -> None:
+        total = len(new_names) + len(overwritten_names)
         if total == 0:
             return
-        box = QMessageBox(
-            QMessageBox.Icon.Information,
-            "Files added",
-            f"Added {total} file(s) — {new_count} new, {overwritten_count} overwritten.",
-            parent=self,
+        message = (
+            f"Added {total} file(s) — {len(new_names)} new, {len(overwritten_names)} overwritten."
         )
-        if overwritten_names:
-            box.setDetailedText("Overwritten files:\n" + "\n".join(overwritten_names))
-        box.exec()
+        AddSummaryDialog(message, new_names, overwritten_names, parent=self).exec()
 
     def is_file_selected(self):
         if not self.listwidget.active_list.is_file_selected():
@@ -1409,7 +1402,7 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                 original_paths[os.path.normpath(temp)] = original
 
         yes_to_all = False
-        new_count = 0
+        new_names = []
         overwritten_names = []
         for url in md.urls():
             local_file = url.toLocalFile()
@@ -1431,16 +1424,16 @@ class MainWindow(QMainWindow, HasUiElements, SearchManager):
                     else self._add_file(local_file, ask_name=not yes_to_all, show_summary=False)
                 )
                 new, names = self._tally(outcome, suggested_name or normalize_name(local_file))
-                new_count += new
+                new_names.extend(new)
                 overwritten_names.extend(names)
                 if outcome is AddOutcome.OVERWRITTEN_ALL:
                     yes_to_all = True
             else:
                 new, names = self._add_folder(local_file, show_summary=False)
-                new_count += new
+                new_names.extend(new)
                 overwritten_names.extend(names)
 
-        self._show_add_summary(new_count, overwritten_names)
+        self._show_add_summary(new_names, overwritten_names)
         event.acceptProposedAction()
 
 

--- a/src/misc.py
+++ b/src/misc.py
@@ -2,17 +2,19 @@ import re
 from typing import TYPE_CHECKING
 
 from pyBIG import base_archive
-from PyQt6.QtCore import QEvent, Qt, QThread, pyqtSignal
+from PyQt6.QtCore import QEvent, QSize, Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QTextOption
 from PyQt6.QtWidgets import (
     QButtonGroup,
     QComboBox,
     QDialog,
     QDialogButtonBox,
+    QHBoxLayout,
     QLabel,
     QLineEdit,
     QMessageBox,
     QRadioButton,
+    QStyle,
     QTabWidget,
     QTextEdit,
     QVBoxLayout,
@@ -243,3 +245,82 @@ class NewTabDialog(QDialog):
         checked_button = self.button_group.checkedButton()
         widget_type = checked_button.text().split()[0].lower()
         return name, widget_type
+
+
+class AddSummaryDialog(QDialog):
+    """Resizable summary shown after add-to-archive operations.
+
+    Unlike ``QMessageBox``, this dialog can be resized and maximized, so the
+    "Show Details" list of new and overwritten files gets more room.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        new_names: list[str],
+        overwritten_names: list[str],
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Files added")
+        self.setWindowFlag(Qt.WindowType.WindowMaximizeButtonHint, True)
+        self.setSizeGripEnabled(True)
+
+        layout = QVBoxLayout(self)
+
+        header = QHBoxLayout()
+        icon = QLabel()
+        icon.setPixmap(
+            self.style()
+            .standardIcon(QStyle.StandardPixmap.SP_MessageBoxInformation)
+            .pixmap(QSize(32, 32))
+        )
+        icon.setAlignment(Qt.AlignmentFlag.AlignTop)
+        header.addWidget(icon)
+        label = QLabel(message)
+        label.setWordWrap(True)
+        header.addWidget(label, 1)
+        layout.addLayout(header)
+
+        details_text = self._build_details(new_names, overwritten_names)
+
+        self.details = QTextEdit()
+        self.details.setReadOnly(True)
+        self.details.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
+        self.details.setPlainText(details_text)
+        self.details.setVisible(False)
+        layout.addWidget(self.details, 1)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok)
+        buttons.accepted.connect(self.accept)
+        if details_text:
+            self.toggle = buttons.addButton("Show Details", QDialogButtonBox.ButtonRole.ActionRole)
+            self.toggle.setCheckable(True)
+            self.toggle.toggled.connect(self._toggle_details)
+        layout.addWidget(buttons)
+
+        self.resize(420, 160)
+
+    @staticmethod
+    def _build_details(new_names: list[str], overwritten_names: list[str]) -> str:
+        """New files first, then a separator, then overwritten files.
+
+        Empty sections are omitted.
+        """
+        sections = []
+        if new_names:
+            sections.append(
+                f"New files ({len(new_names)}):\n" + "\n".join(f"  {name}" for name in new_names)
+            )
+        if overwritten_names:
+            sections.append(
+                f"Overwritten files ({len(overwritten_names)}):\n"
+                + "\n".join(f"  {name}" for name in overwritten_names)
+            )
+        return ("\n" + "─" * 40 + "\n").join(sections)
+
+    def _toggle_details(self, shown: bool) -> None:
+        self.details.setVisible(shown)
+        self.toggle.setText("Hide Details" if shown else "Show Details")
+        if shown and self.height() < 320:
+            self.resize(self.width(), 360)


### PR DESCRIPTION
## Summary

After add-to-archive operations, show an information dialog summarizing how many files were added — split into **new** vs **overwritten**.

Previously, when the **Add Overwrite Default** is set to **Overwrite**, existing files were replaced silently; the only feedback was the `*` modified-marker in the title bar. This adds explicit confirmation.

## Where it fires

- Single file add (`_add_file` / `_add_file_with_name`)
- Folder add (`_add_folder`)
- Archive merge (`merge_archives` — one combined summary across all source archives)
- Drag-and-drop (one aggregated summary for the whole drop, instead of one popup per item)

The disk-extract flow (`extract` / `extract_all` / `extract_filtered`) is intentionally left as-is — it delegates to the `pyBIG` library and does not surface per-file overwrite info.

## Details

The dialog shows e.g. `Added 2019 file(s) — 2016 new, 3 overwritten.` When any files were overwritten, their names are listed under the dialog's **Show Details...** button, so long lists stay collapsed by default.

## Notes

- In the drag-and-drop single-file path with **smart replace** enabled, the detail list shows the dropped file name rather than the resolved (renamed) archive target. The folder-add and merge paths — where bulk overwrites typically happen — always show exact archive names.